### PR TITLE
Only allow one solution per user

### DIFF
--- a/app/controllers/solutions_controller.rb
+++ b/app/controllers/solutions_controller.rb
@@ -34,7 +34,13 @@ class SolutionsController < ApplicationController
 
   def index; end
 
-  def new; end
+  def new
+    if current_user.solution.nil?
+      render :new
+    else
+      redirect_to edit_solution_path(current_user.solution)
+    end
+  end
 
   def destroy
     if solution.delete

--- a/app/controllers/solutions_controller.rb
+++ b/app/controllers/solutions_controller.rb
@@ -6,6 +6,8 @@ class SolutionsController < ApplicationController
   before_action :authenticate_can_edit!, only: %i[update edit]
 
   before_action :authenticate_can_show_archived!, only: %i[show]
+  before_action :set_cache_headers, only: %i[new]
+  
   expose :solution, scope: :with_deleted
 
   expose :winning_solutions, -> { Solution.winners }
@@ -76,6 +78,12 @@ class SolutionsController < ApplicationController
   end
 
   private
+  
+  def set_cache_headers
+    response.headers['Cache-Control'] = 'no-cache, no-store'
+    response.headers['Pragma'] = 'no-cache'
+    response.headers['Expires'] = 'Fri, 01 Jan 1990 00:00:00 GMT'
+  end
 
   def authenticate_can_show_archived!
     return unless solution.deleted?

--- a/app/views/layouts/_site_header.html.haml
+++ b/app/views/layouts/_site_header.html.haml
@@ -9,7 +9,10 @@
     %nav
       = link_to t('buttons.overview'), :root, id: 'overview_nav'
       - if ApplicationState.instance.collection?
-        = link_to t('buttons.submit_solution'), current_user ? :new_solution : :new_user_registration, id: 'submit_nav'
+        - if current_user && current_user.solution.present?
+          = link_to t('buttons.edit_solution'), edit_solution_path(current_user.solution), id: 'submit_nav'
+        - else
+          = link_to t('buttons.submit_solution'), current_user ? :new_solution : :new_user_registration, id: 'submit_nav'
       = link_to t('buttons.browse_solution'), :solutions, id: 'browse_nav'
       - if current_user
         =link_to t('buttons.admin'), :edit_admin_application_state if admin_logged_in

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,6 +13,7 @@ en:
   buttons:
     overview: "Overview"
     submit_solution: "Submit Your Solution"
+    edit_solution: "Edit Your Solution"
     browse_solution: "Browse All Solutions"
     view_all: "View all solutions"
     log_out: "Log out"


### PR DESCRIPTION
This redirects a user to edit their existing solution if they try and create a new one, and also prevents caching of the new action, so additional solutions can't be created by accident